### PR TITLE
Change param list to keep compatible

### DIFF
--- a/extra.py
+++ b/extra.py
@@ -100,7 +100,7 @@ class TimeDistributedConvolution2D(Layer):
             raise Exception('Invalid dim_ordering: ' + self.dim_ordering)
         self.W = self.init(self.W_shape)
         self.b = K.zeros((self.nb_filter,))
-        self.params = [self.W, self.b]
+        self.trainable_weights = [self.W, self.b]
         self.regularizers = []
 
         if self.W_regularizer:


### PR DESCRIPTION
Keras now uses `trainable_weights` and `non_trainable_weights` to store parameters in layer classes. Only 1 line changed just to keep compatible with this.
